### PR TITLE
[ch10-03] Fix wording change about mandatory type annotation

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -8,7 +8,7 @@ One detail we didn’t discuss in the [“References and
 Borrowing”][references-and-borrowing]<!-- ignore --> section in Chapter 4 is
 that every reference in Rust has a *lifetime*, which is the scope for which
 that reference is valid. Most of the time, lifetimes are implicit and inferred,
-just like most of the time, types are inferred. We must only annotate types
+just like most of the time, types are inferred. We only have to annotate types
 when multiple types are possible. In a similar way, we must annotate lifetimes
 when the lifetimes of references could be related in a few different ways. Rust
 requires us to annotate the relationships using generic lifetime parameters to


### PR DESCRIPTION
The wording change in 66aedb4 made this sentence flow more nicely, but is a little misleading because it implies types can't be annotated if there is only one possible type. This changes it back to it's previous order but replaces "must" with "have to" to keep it's correctness while still flowing more naturally.

Technically it's still a little incorrect because types have to be annotated in type signatures even if there is only one possible type. Maybe the word "only" in this sentence should be removed?